### PR TITLE
Fix the version issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <plugin>
             <groupId>org.jbehave</groupId>
             <artifactId>jbehave-maven-plugin</artifactId>
+            <version>2.3.2</version>
             <executions>
                 <execution>
                     <id>run-stories</id>


### PR DESCRIPTION
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for net.masterthought.example:jbehave-example:jar:0.0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.jbehave:jbehave-maven-plugin is missing. @ line 27, column 17
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building jbehave 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]